### PR TITLE
refactor(tests): define account addresses in a helper class

### DIFF
--- a/tests/frontier/opcodes/test_callcode.py
+++ b/tests/frontier/opcodes/test_callcode.py
@@ -4,11 +4,12 @@ abstract: Tests the CALLCODE gas consumption with a CALL/CALLCODE value transfer
     Tests an EthereumJS bug where the CALLCODE gas was incorrectly calculated from a
     CALL value transfer: https://github.com/ethereumjs/ethereumjs-monorepo/issues/3194
 
-    Test setup: 2 smart contract accounts exist where AAAB CALL/CALLCODEs AAAA, which then
-    CALLCODEs a non-existent contract AAAC. The result of AAAA's CALL/CALLCODE is stored in AAAB's
-    storage slot 0.
+    Test setup: Given two smart contract accounts, AAAA and AAAB:
+    - AAAA CALL/CALLCODEs AAAB which then CALLCODEs a non-existent contract AAAC.
+    - The result of AAAB's CALL/CALLCODE is stored in AAAA's storage slot 0.
 """
 
+from dataclasses import dataclass
 from typing import Dict
 
 import pytest
@@ -24,19 +25,26 @@ from ethereum_test_tools import (
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 
+@dataclass(frozen=True)
+class Accounts:  # noqa: D101
+    caller: int = 0xAAAA
+    callee: int = 0xAAAB
+    nonexistent_callee: int = 0xAAAC
+
+
 @pytest.fixture
 def caller_code(caller_gas, caller_type):
     """
     Code to call the callee contract:
         PUSH1 0x00
         DUP1 * 4
-        PUSH2 0xAAAA
+        PUSH2 Accounts.callee
         PUSH2 call_gas
         CALL/CALLCODE
         PUSH1 0x00
         SSTORE
     """
-    return Op.SSTORE(0, caller_type(caller_gas, 0xAAAA, 0, 0, 0, 0, 0))
+    return Op.SSTORE(0, caller_type(caller_gas, Accounts.callee, 0, 0, 0, 0, 0))
 
 
 @pytest.fixture
@@ -46,11 +54,11 @@ def callee_code():
         PUSH1 0x00 * 4
         PUSH1 0x00
         PUSH1 0x00
-        PUSH2 0xAACC
+        PUSH2 Accounts.nonexistent_callee
         PUSH2 0x1a90
         CALLCODE
     """
-    return Op.CALLCODE(0x1A90, 0xAACC, 1, 0, 0, 0, 0)
+    return Op.CALLCODE(0x1A90, Accounts.nonexistent_callee, 1, 0, 0, 0, 0)
 
 
 @pytest.fixture
@@ -61,7 +69,7 @@ def caller_tx() -> Transaction:
     return Transaction(
         chain_id=0x01,
         nonce=0,
-        to=to_address(0xAAAB),
+        to=to_address(Accounts.caller),
         value=1,
         gas_limit=500000,
         gas_price=7,
@@ -71,12 +79,12 @@ def caller_tx() -> Transaction:
 @pytest.fixture
 def pre(callee_code, caller_code) -> Dict[str, Account]:  # noqa: D103
     return {
-        to_address(0xAAAA): Account(
+        to_address(Accounts.callee): Account(
             balance=0x03,
             code=callee_code,
             nonce=1,
         ),
-        to_address(0xAAAB): Account(
+        to_address(Accounts.caller): Account(
             balance=0x03,
             code=caller_code,
             nonce=1,
@@ -90,7 +98,9 @@ def pre(callee_code, caller_code) -> Dict[str, Account]:  # noqa: D103
 @pytest.fixture
 def post(caller_gas) -> Dict[str, Account]:  # noqa: D103
     return {
-        to_address(0xAAAB): Account(storage={0x00: (0x01 if caller_gas >= 0x3D50 else 0x00)}),
+        to_address(Accounts.caller): Account(
+            storage={0x00: (0x01 if caller_gas >= 0x3D50 else 0x00)}
+        ),
     }
 
 


### PR DESCRIPTION
## 🗒️ Description

Hey, I just added a little helper dataclass to define account names with the aim of making the code easier to read. I also switched out 0xAAAA and 0xAAAB, as I found 0xAAAA callcodes 0xAAAB which callcodes 0xAAAC more logical (than 0xAAAB->0xAAAA->0xAAAC). Hope I didn't miss some intention here?
